### PR TITLE
Fix: Correct parameter name in crop_image call

### DIFF
--- a/test_single_image.py
+++ b/test_single_image.py
@@ -81,7 +81,7 @@ def main():
     print(f"Reading input image: {args.input_path}")
     C = read_image(args.input_path, divisor)
     C = torch.FloatTensor(C.transpose(0, 3, 1, 2).copy()).cuda()
-    C, h, w = crop_image(C, 8, return_hw=True) # pad=8 as in run.py
+    C, h, w = crop_image(C, 8, size=True) # pad=8 as in run.py, use size=True
 
     if is_dual_mode:
         print(f"Reading left image: {args.left_image_path}")


### PR DESCRIPTION
Changed the call to `crop_image` in `test_single_image.py` to use `size=True` instead of the incorrect `return_hw=True`.

This aligns with the function definition in `util/util.py` and resolves the TypeError, ensuring that original image dimensions are correctly retrieved for output cropping.